### PR TITLE
add initial implementation and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,145 @@
 
 Store records in Redis with MuchRails.
 
+Note: I find redis to be a good choice for one-off "token" type records or any temporary record you want removed after a certain amount of time. MuchRailsRedisRecord is ideal for these types of records.
+
+For typical records in Rails, ActiveRecord should be preferred.
+
+## Setup
+
+### Mixin on your record object you want persisted in Redis, e.g.:
+
+```ruby
+class Thing
+  include MuchRailsRedisRecord
+
+  def self.TTL_SECS
+    @ttl_secs ||= 5 * 60 # 5 minutes
+  end
+
+  def self.REDIS_KEY_NAMESPACE
+    "things"
+  end
+
+  attr_accessor :name
+
+  def initialize(name:, **kargs)
+    super(**kargs)
+
+    @name = name
+  end
+
+  def to_h
+    {
+      "name" => name,
+    }
+  end
+
+  private
+
+  def on_validate
+    validate_presence
+  end
+
+  def validate_presence
+    errors[:name] << "can't be blank" if name.blank?
+  end
+end
+```
+
+### Configure the redis connection
+
+In e.g. `config/initializers/much_rails.rb`:
+
+```ruby
+MuchRailsRedisRecord.config.redis =
+  HellaRedis.new({
+    url: ENV.fetch("REDIS_URL"){ "redis://localhost:6379/0" },
+    driver: "ruby",
+    redis_ns: "my-app",
+    size: ENV.fetch("APP_MAX_THREADS"){ 5 },
+    timeout: 1,
+  })
+```
+
 ## Usage
 
-TODO: Write code samples and usage instructions here
+```
+$ rails c
+Loading development environment (Rails 6.1.3.1)
+[1] pry(main)> chair = Thing.new(name: "Chair")
+=> #<Thing:0x00007fd404182358 @created_at=nil, @identifier=nil, @name="Chair", @updated_at=nil, @valid=nil>
+[2] pry(main)> chair.save!
+=> true
+[3] pry(main)> chair
+=> #<Thing:0x00007fd404182358 @created_at=2021-06-17 13:16:52.059503 UTC, @errors={}, @identifier="6600bdd3-4dc8-447b-910a-3cf079eaae98", @name="Chair", @updated_at=2021-06-17 13:16:52.059506 UTC, @valid=nil>
+[4] pry(main)> chair.name = "Comfy chair"
+=> "Comfy chair"
+[5] pry(main)> chair.save!
+=> true
+[6] pry(main)> chair
+=> #<Thing:0x00007fd404182358 @created_at=2021-06-17 13:16:52.059503 UTC, @errors={}, @identifier="6600bdd3-4dc8-447b-910a-3cf079eaae98", @name="Comfy chair", @updated_at=2021-06-17 13:17:12.409879 UTC, @valid=nil>
+[7] pry(main)> chair.valid?
+=> true
+[8] pry(main)> chair.name = nil
+=> nil
+[9] pry(main)> chair.valid?
+=> false
+[10] pry(main)> chair.save!
+MuchRails::InvalidError: {"name"=>["can't be blank"]}
+from /Users/kelly/projects/redding/gems/much-rails-redis-record/lib/much-rails-redis-record.rb:156:in `validate!'
+[11] pry(main)> chair.name = "Comfy chair"
+=> "Comfy chair"
+[12] pry(main)> chair.valid?
+=> true
+[13] pry(main)> chair.ttl
+=> 242
+[14] pry(main)> chair.ttl
+=> 239
+[15] pry(main)> chair.ttl
+=> 235
+[16] pry(main)> chair.redis_key
+=> "things:6600bdd3-4dc8-447b-910a-3cf079eaae98"
+[17] pry(main)> Thing.find_by_identifier("6600bdd3-4dc8-447b-910a-3cf079eaae98")
+=> #<Thing:0x00007fd4043d97c8 @created_at=2021-06-17 13:16:52 UTC, @identifier="6600bdd3-4dc8-447b-910a-3cf079eaae98", @name="Comfy chair", @updated_at=2021-06-17 13:17:12 UTC, @valid=nil>
+[18] pry(main)> chair == Thing.find_by_identifier("6600bdd3-4dc8-447b-910a-3cf079eaae98")
+=> true
+[19] pry(main)> Thing.find_all
+=> [#<Thing:0x00007fd40440af30 @created_at=2021-06-17 13:16:52 UTC, @identifier="6600bdd3-4dc8-447b-910a-3cf079eaae98", @name="Comfy chair", @updated_at=2021-06-17 13:17:12 UTC, @valid=nil>]
+[20] pry(main)> chair.destroy!
+=> true
+[21] pry(main)> Thing.find_all
+=> []
+[22] pry(main)>
+```
+
+## Testing
+
+### Fake redis records
+
+Use `MuchRailsRedisRecord::FakeBehaviors` to create test doubles for your redis records. The test doubles have the same API but won't call out to redis to persist.
+
+E.g.
+
+```ruby
+require "much-rails-redis-record/fake_behaviors"
+
+class Factory::FakeThing < Thing
+  include MuchRailsRedisRecord::FakeBehaviors
+
+  def initialize(name: nil, **kargs)
+    super(name || Factory.string, **kargs)
+  end
+end
+```
+
+```
+[3] pry(main)> fake_thing = Factory::FakeThing.new
+=> #<Factory::FakeThing:0x00007f98b0865740 @created_at=2000-12-21 05:11:53 UTC, @identifier="6c8f6609-b459-4a8f-b5e2-df1bb02efbaa", @name="ygzzysbhip", @updated_at=2000-04-01 02:17:30 UTC, @valid=nil>
+[4] pry(main)> Thing.find_all
+=> []
+[5] pry(main)>
+```
 
 ## Installation
 

--- a/lib/much-rails-redis-record.rb
+++ b/lib/much-rails-redis-record.rb
@@ -1,6 +1,172 @@
 # frozen_string_literal: true
 
+require "much-rails"
+require "hella-redis"
 require "much-rails-redis-record/version"
 
 module MuchRailsRedisRecord
+  include MuchRails::Config
+  include MuchRails::Mixin
+
+  add_config
+
+  mixin_included do
+    attr_accessor :identifier, :created_at, :updated_at
+  end
+
+  mixin_class_methods do
+    def TTL_SECS
+      raise NotImplementedError
+    end
+
+    def REDIS_KEY_NAMESPACE
+      raise NotImplementedError
+    end
+
+    def redis
+      MuchRailsRedisRecord.config.redis
+    end
+
+    def redis_key(identifier)
+      "#{self.REDIS_KEY_NAMESPACE}:#{identifier}"
+    end
+
+    def find_by_identifier(identifier)
+      find_by_redis_key(redis_key(identifier))
+    end
+
+    def find_by_redis_key(redis_key)
+      args =
+        MuchRails::JSON.decode(
+          redis.connection do |c|
+            unless c.exists?(redis_key)
+              raise MuchRailsRedisRecord::NotFoundError
+            end
+
+            c.get(redis_key)
+          end,
+        )
+      new(**args.symbolize_keys)
+    end
+
+    # Note: this should not be used in production code for performance / memory
+    # consumption reasons. This should only be used for debugging in development
+    # and staging environments.
+    def find_all_redis_keys
+      redis.connection do |c|
+        c.keys("#{self.REDIS_KEY_NAMESPACE}:*")
+      end
+    end
+
+    # Note: this should not be used in production code for performance / memory
+    # consumption reasons. This should only be used for debugging in development
+    # and staging environments.
+    def find_all
+      find_all_redis_keys.map do |redis_key|
+        find_by_redis_key(redis_key)
+      end
+    end
+  end
+
+  mixin_instance_methods do
+    def initialize(
+          identifier: Value.not_given,
+          created_at: Value.not_given,
+          updated_at: Value.not_given,
+          **)
+      @identifier = Value.given?(identifier) ? identifier : nil
+      @created_at =
+        Value.given?(created_at) ? MuchRails::Time.for(created_at) : nil
+      @updated_at =
+        Value.given?(updated_at) ? MuchRails::Time.for(updated_at) : nil
+
+      @valid = nil
+    end
+
+    def valid?
+      errors.clear
+      on_validate
+      errors.none?
+    end
+
+    def redis_key
+      self.class.redis_key(identifier)
+    end
+
+    def ttl
+      redis.connection{ |c| c.ttl(redis_key) }
+    end
+
+    def errors
+      @errors ||= HashWithIndifferentAccess.new{ |hash, key| hash[key] = [] }
+    end
+
+    def save!
+      validate!
+      set_save_transaction_data
+
+      redis.connection do |c|
+        c.multi do
+          c.set(
+            redis_key,
+            MuchRails::JSON.encode(
+              to_h.merge({
+                "identifier" => identifier,
+                "created_at" => created_at.iso8601,
+                "updated_at" => updated_at.iso8601,
+              }),
+            ),
+          )
+          c.expire(redis_key, self.class.TTL_SECS) if self.class.TTL_SECS
+        end
+      end
+
+      true
+    end
+
+    def destroy!
+      redis.connection{ |c| c.del(redis_key) } if identifier
+
+      true
+    end
+
+    def to_h
+      raise NotImplementedError
+    end
+
+    def ==(other)
+      return super unless other.is_a?(self.class)
+
+      to_h == other.to_h
+    end
+
+    private
+
+    def redis
+      self.class.redis
+    end
+
+    def set_save_transaction_data
+      @identifier ||= SecureRandom.uuid
+      @created_at ||= Time.now.utc
+      @updated_at = Time.now.utc
+    end
+
+    def validate!
+      raise(MuchRails::InvalidError.new(**errors)) unless valid?
+    end
+
+    def on_validate
+    end
+  end
+
+  NotFoundError = Class.new(RuntimeError)
+
+  module Value
+    include MuchRails::NotGiven
+  end
+
+  class Config
+    attr_accessor :redis
+  end
 end

--- a/lib/much-rails-redis-record/fake_behaviors.rb
+++ b/lib/much-rails-redis-record/fake_behaviors.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module MuchRailsRedisRecord; end
+
+module MuchRailsRedisRecord::FakeBehaviors
+  include MuchRails::Mixin
+
+  mixin_instance_methods do
+    def initialize(
+          identifier: Value.not_given,
+          created_at: Value.not_given,
+          updated_at: Value.not_given,
+          **kargs)
+      super(
+        identifier: Value.given?(identifier) ? identifier : Factory.uuid,
+        created_at: Value.given?(created_at) ? created_at : Factory.time.utc,
+        updated_at: Value.given?(updated_at) ? updated_at : Factory.time.utc,
+        **kargs,
+      )
+    end
+
+    def save_bang_called?
+      !!@save_bang_called
+    end
+
+    def destroy_bang_called?
+      !!@destroy_bang_called
+    end
+
+    def save!
+      validate!
+      set_save_transaction_data
+
+      @save_bang_called = true
+
+      true
+    end
+
+    def destroy!
+      @destroy_bang_called = true if identifier
+    end
+  end
+
+  Value = MuchRailsRedisRecord::Value
+end

--- a/much-rails-redis-record.gemspec
+++ b/much-rails-redis-record.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("much-style-guide", ["~> 0.6.4"])
   gem.add_development_dependency("assert",           ["~> 2.19.6"])
 
+  gem.add_dependency("much-rails", ["~> 0.4.2"])
   gem.add_dependency("hella-redis", ["~> 0.5.0"])
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+ENV["HELLA_REDIS_TEST_MODE"] = "yes"
+
 # Add the root dir to the load path.
 $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 
@@ -7,3 +9,15 @@ $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 require "pry"
 
 require "test/support/factory"
+require "much-rails-redis-record"
+
+MuchRailsRedisRecord.configure do |config|
+  config.redis =
+    HellaRedis.new({
+      url: ENV.fetch("REDIS_URL"){ "redis://localhost:6379/0" },
+      driver: "ruby",
+      redis_ns: "much-rails-redis-record:tests",
+      size: ENV.fetch("APP_MAX_THREADS"){ 5 },
+      timeout: 1,
+    })
+end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -4,4 +4,8 @@ require "assert/factory"
 
 module Factory
   extend Assert::Factory
+
+  def self.uuid
+    SecureRandom.uuid
+  end
 end

--- a/test/unit/much-rails-redis-record_tests.rb
+++ b/test/unit/much-rails-redis-record_tests.rb
@@ -1,0 +1,397 @@
+# frozen_string_literal: true
+
+require "assert"
+require "much-rails-redis-record"
+
+module MuchRailsRedisRecord
+  class UnitTests < Assert::Context
+    desc "MuchRailsRedisRecord"
+    subject{ unit_module }
+
+    let(:unit_module){ MuchRailsRedisRecord }
+  end
+
+  class ReceiverTests < UnitTests
+    desc "receiver"
+    subject{ receiver_class }
+
+    setup do
+      redis.reset!
+
+      secure_random_uuid
+      Assert.stub(SecureRandom, :uuid){ secure_random_uuid }
+    end
+
+    teardown do
+      redis.reset!
+    end
+
+    let(:receiver_class) do
+      Class
+        .new{
+          def self.TTL_SECS
+            1
+          end
+
+          def self.REDIS_KEY_NAMESPACE
+            "test:redis-records"
+          end
+
+          attr_reader :field1
+
+          def initialize(
+                field1:,
+                **kargs)
+            super(**kargs)
+
+            @field1 = field1.to_s.strip
+          end
+
+          def to_h
+            {
+              "field1" => field1,
+            }
+          end
+
+          private
+
+          def on_validate
+            validate_presence
+          end
+
+          def validate_presence
+            errors[:field1] << "can’t be blank" if field1.blank?
+          end
+        }
+        .tap do |c|
+          c.include(unit_module)
+        end
+    end
+
+    let(:redis){ unit_module.config.redis }
+    let(:secure_random_uuid){ Factory.uuid }
+
+    let(:field1_value){ Factory.string }
+    let(:identifier){ secure_random_uuid }
+    let(:created_at){ Time.now.utc }
+    let(:updated_at){ Time.now.utc }
+
+    let(:record_data) do
+      {
+        "field1" => field1_value,
+        "identifier" => identifier,
+        "created_at" => created_at.iso8601,
+        "updated_at" => updated_at.iso8601,
+      }
+    end
+
+    should have_imeths :TTL_SECS, :REDIS_KEY_NAMESPACE
+    should have_imeths :redis_key, :find_by_identifier, :find_by_redis_key
+    should have_imeths :find_all_redis_keys, :find_all
+
+    should "know its attributes" do
+      assert_that(subject.TTL_SECS).equals(1)
+      assert_that(subject.REDIS_KEY_NAMESPACE).equals("test:redis-records")
+      assert_that(subject.redis_key(secure_random_uuid))
+        .equals("#{subject.REDIS_KEY_NAMESPACE}:#{identifier}")
+    end
+  end
+
+  class FindByIdentifierSetupTests < ReceiverTests
+    desc ".find_by_identifier"
+
+    setup do
+      Assert
+        .stub(redis.connection_spy, :get)
+        .with(subject.redis_key(identifier)){ encoded_record_data }
+    end
+
+    let(:encoded_record_data){ MuchRails::JSON.encode(record_data) }
+  end
+
+  class FindByExistingIdentifierTests < FindByIdentifierSetupTests
+    desc "with an existing identifier"
+
+    setup do
+      Assert
+        .stub(redis.connection_spy, :exists?)
+        .with(subject.redis_key(identifier)){ true }
+    end
+
+    should "lookup the existing record data and build an instance with it" do
+      record = subject.find_by_identifier(identifier)
+      assert_that(record).equals(subject.new(**record_data.symbolize_keys))
+    end
+  end
+
+  class FindByNonExistingIdentifierTests < FindByIdentifierSetupTests
+    desc "with an non-existing identifier"
+
+    setup do
+      Assert
+        .stub(redis.connection_spy, :exists?)
+        .with(subject.redis_key(identifier)){ false }
+    end
+
+    should "raise an exception" do
+      assert_that{ subject.find_by_identifier(identifier) }
+        .raises(subject::NotFoundError)
+    end
+  end
+
+  class FindByRedisKeySetupTests < ReceiverTests
+    desc ".find_by_redis_key"
+
+    setup do
+      Assert
+        .stub(redis.connection_spy, :get)
+        .with(subject.redis_key(identifier)){ encoded_record_data }
+    end
+
+    let(:encoded_record_data){ MuchRails::JSON.encode(record_data) }
+  end
+
+  class FindByExistingRedisKeyTests < FindByRedisKeySetupTests
+    desc "with an existing redis key"
+
+    setup do
+      Assert
+        .stub(redis.connection_spy, :exists?)
+        .with(subject.redis_key(identifier)){ true }
+    end
+
+    should "lookup the existing record data and build an instance with it" do
+      record = subject.find_by_redis_key(subject.redis_key(identifier))
+      assert_that(record).equals(subject.new(**record_data.symbolize_keys))
+    end
+  end
+
+  class FindByNonExistingRedisKeyTests < FindByRedisKeySetupTests
+    desc "with an non-existing redis key"
+
+    setup do
+      Assert
+        .stub(redis.connection_spy, :exists?)
+        .with(subject.redis_key(identifier)){ false }
+    end
+
+    should "raise an exception" do
+      assert_that{ subject.find_by_redis_key(subject.redis_key(identifier)) }
+        .raises(subject::NotFoundError)
+    end
+  end
+
+  class FindAllRedisKeysTests < ReceiverTests
+    desc ".find_all_redis_keys"
+
+    setup do
+      Assert
+        .stub(redis.connection_spy, :keys)
+        .with("#{receiver_class.REDIS_KEY_NAMESPACE}:*"){ all_redis_keys }
+    end
+
+    let(:all_redis_keys) do
+      Array.new(Factory.integer(3)) do
+        "#{receiver_class.REDIS_KEY_NAMESPACE}:#{Factory.uuid}"
+      end
+    end
+
+    should "lookup all redis keys matching the key namespace" do
+      assert_that(subject.find_all_redis_keys).equals(all_redis_keys)
+    end
+  end
+
+  class FindAllTests < ReceiverTests
+    desc ".find_all_tests"
+
+    setup do
+      Assert.stub(receiver_class, :find_all_redis_keys) do
+        redis_record_redis_keys
+      end
+      Assert
+        .stub(receiver_class, :find_by_redis_key)
+        .with(redis_record_redis_keys.first) do
+          redis_records.first
+        end
+    end
+
+    let(:redis_records) do
+      [receiver_class.new(**record_data.symbolize_keys)]
+    end
+    let(:redis_record_redis_keys){ redis_records.map(&:redis_key) }
+
+    should "lookup all redis keys matching the key namespace" do
+      assert_that(subject.find_all).equals(redis_records)
+    end
+  end
+
+  class InitTests < ReceiverTests
+    desc "when init"
+    subject{ receiver_class.new(field1: field1_value) }
+
+    should have_imeths :valid?, :errors, :save!, :destroy!, :to_h
+
+    should "know its attributes" do
+      assert_that(subject.valid?).equals(true)
+      assert_that(subject.errors).equals({})
+      assert_that(subject.to_h)
+        .equals({
+          "field1" => field1_value,
+        })
+    end
+  end
+
+  class SaveSetupTests < InitTests
+    desc ".save!"
+
+    setup do
+      create_time_now
+      Assert.stub(Time, :now){ create_time_now }
+    end
+
+    let(:create_time_now){ Time.now }
+  end
+
+  class SaveNewRecordTests < SaveSetupTests
+    desc "on a new record"
+
+    should "set save data and save the record" do
+      assert_that(subject.identifier).is_nil
+      assert_that(subject.created_at).is_nil
+      assert_that(subject.updated_at).is_nil
+
+      result = subject.save!
+      assert_that(result).is_true
+
+      assert_that(subject.identifier).equals(identifier)
+      assert_that(subject.created_at).equals(create_time_now)
+      assert_that(subject.updated_at).equals(create_time_now)
+
+      assert_that(redis.calls.size).equals(3)
+      multi_call, set_call, expire_call = redis.calls
+
+      assert_that(multi_call.command).equals(:multi)
+
+      assert_that(set_call.command).equals(:set)
+      assert_that(set_call.args)
+        .equals([
+          subject.class.redis_key(identifier),
+          MuchRails::JSON.encode(
+            subject.to_h.merge({
+              "identifier" => subject.identifier,
+              "created_at" => subject.created_at.iso8601,
+              "updated_at" => subject.updated_at.iso8601,
+            }),
+          ),
+        ])
+
+      assert_that(expire_call.command).equals(:expire)
+      assert_that(expire_call.args)
+        .equals([subject.class.redis_key(identifier), subject.class.TTL_SECS])
+    end
+  end
+
+  class SaveExistingRecordTests < SaveSetupTests
+    desc "on an existing record"
+
+    setup do
+      subject.save!
+
+      Assert.unstub(Time, :now)
+      update_time_now
+      Assert.stub(Time, :now){ update_time_now }
+
+      redis.reset!
+    end
+
+    let(:update_time_now){ Time.now }
+
+    should "set save data and save the record" do
+      assert_that(subject.identifier).equals(identifier)
+      assert_that(subject.created_at).equals(create_time_now)
+      assert_that(subject.updated_at).equals(create_time_now)
+
+      result = subject.save!
+      assert_that(result).is_true
+
+      assert_that(subject.identifier).equals(identifier)
+      assert_that(subject.created_at).equals(create_time_now)
+      assert_that(subject.updated_at).equals(update_time_now)
+    end
+  end
+
+  class SaveWithNoTTLTests < SaveSetupTests
+    desc "with no TTL_SECS"
+
+    setup do
+      Assert.stub(receiver_class, :TTL_SECS){ nil }
+    end
+
+    should "set save data and save the record" do
+      subject.save!
+
+      assert_that(redis.calls.size).equals(2)
+      multi_call, set_call = redis.calls
+
+      assert_that(multi_call.command).equals(:multi)
+      assert_that(set_call.command).equals(:set)
+    end
+  end
+
+  class SaveWithValidationErrorsTests < SaveSetupTests
+    desc "with validation errors"
+
+    setup do
+      Assert.stub(subject, :field1){ [nil, ""].sample }
+    end
+
+    should "not set save data and not save the record" do
+      assert_that(subject.valid?).equals(false)
+      exception =
+        assert_that{ subject.save! }.raises(MuchRails::InvalidError)
+
+      assert_that(exception.errors).equals(subject.errors)
+      assert_that(redis.calls.size).equals(0)
+    end
+  end
+
+  class DestroySetupTests < InitTests
+    desc ".destroy!"
+  end
+
+  class DestroyNewRecordTests < DestroySetupTests
+    desc "on a new record"
+
+    should "do nothing in Redis" do
+      assert_that(subject.identifier).is_nil
+
+      result = subject.destroy!
+      assert_that(result).is_true
+
+      assert_that(redis.calls.size).equals(0)
+    end
+  end
+
+  class DestroyExistingRecordTests < DestroySetupTests
+    desc "on an existing record"
+
+    setup do
+      subject.save!
+      redis.reset!
+    end
+
+    should "delete the record in Redis" do
+      assert_that(subject.identifier).is_not_nil
+
+      result = subject.destroy!
+      assert_that(result).is_true
+
+      assert_that(redis.calls.size).equals(1)
+      delete_call = redis.calls.last
+
+      assert_that(delete_call.command).equals(:del)
+      assert_that(delete_call.args)
+        .equals([subject.class.redis_key(identifier)])
+    end
+  end
+end


### PR DESCRIPTION
This adds a MuchRailsRedisRecord mixin for defining redis records
in MuchRails. This is the initial implementation I've extracted
out of other projects.

# Other Changes

### add first-pass README

This outlines the setup/usage/testing instructions and examples.
